### PR TITLE
fix regexp of `getAskingPlace`

### DIFF
--- a/functions/response.ts
+++ b/functions/response.ts
@@ -154,7 +154,7 @@ function isRecommendedPlace(place: string): boolean {
  * @returns {string} Matched regexp
  */
 function getAskingPlace(q: string): string {
-  const regexp = /^今日[は]*(.+)で花金[？|?]$/;
+  const regexp = /^今日は?(.+)で花金[？?]$/;
   const result = q.match(regexp);
   const matched = result && result[1];
   const msg = matched ?? "";


### PR DESCRIPTION
## Original
- RegExp: `/^今日[は]*(.+)で花金[？|?]$/`
  - [![image](https://user-images.githubusercontent.com/19568747/204453980-847dadbe-d5e6-44e3-95d7-7d2be1175a03.png)](https://regexper.com/#%2F%5E%E4%BB%8A%E6%97%A5%5B%E3%81%AF%5D*%28.%2B%29%E3%81%A7%E8%8A%B1%E9%87%91%5B%EF%BC%9F%7C%3F%5D%24%2F)
- `regexp.test('今日はははわいで花金？') === true` (group: `わい`)
- `regexp.test('今日は目黒で花金|') === true`

## Fixed
- RegExp: `/^今日は?(.+)で花金[？?]$/`
  - [![image](https://user-images.githubusercontent.com/19568747/204454434-063ac98c-2bf1-406a-9db7-e4c018bad476.png)](https://regexper.com/#%2F%5E%E4%BB%8A%E6%97%A5%E3%81%AF%3F%28.%2B%29%E3%81%A7%E8%8A%B1%E9%87%91%5B%EF%BC%9F%3F%5D%24%2F)
- `regexp.test('今日ははわい目黒で花金？') === true` (group: `'はわい'`)
- `regexp.test('今日は目黒で花金|') === false`
